### PR TITLE
Added error handling for upgradeSoftwareVersion

### DIFF
--- a/server/service/IndividualServicesService.js
+++ b/server/service/IndividualServicesService.js
@@ -105,7 +105,8 @@ exports.bequeathYourDataAndDie = function (body, user, originator, xCorrelator, 
           );
         }
       }
-      softwareUpgrade.upgradeSoftwareVersion(isdataTransferRequired, user, xCorrelator, traceIndicator, customerJourney);
+      softwareUpgrade.upgradeSoftwareVersion(isdataTransferRequired, user, xCorrelator, traceIndicator, customerJourney)
+        .catch(err => console.log(`upgradeSoftwareVersion failed with error: ${err}`));
       resolve();
     } catch (error) {
       reject(error);

--- a/server/service/individualServices/SoftwareUpgrade.js
+++ b/server/service/individualServices/SoftwareUpgrade.js
@@ -26,6 +26,7 @@ const OamRecordProfile = require('onf-core-model-ap/applicationPattern/onfModel/
  * @param {String} xCorrelator UUID for the service execution flow that allows to correlate requests and responses
  * @param {String} traceIndicator Sequence of request numbers along the flow
  * @param {String} customerJourney Holds information supporting customer’s journey to which the execution applies
+ * @returns {Promise} Promise is resolved if the operation succeeded else the Promise is rejected
  * **/
 exports.upgradeSoftwareVersion = async function (isdataTransferRequired, user, xCorrelator, traceIndicator, customerJourney) {
     return new Promise(async function (resolve, reject) {


### PR DESCRIPTION
upgradeSoftwareVersion returns Promise which is rejected in case
of any step fails. Rejected Promise was not handled.
This commit adds catching of such case.

Fixes #43 

Signed-off-by: Martin Sunal <martin.sunal@paxet.io>